### PR TITLE
Improve Composer configuration

### DIFF
--- a/salt/journal/init.sls
+++ b/salt/journal/init.sls
@@ -82,11 +82,19 @@ web-assets-symlink-cleaning:
 
 composer-install:
     cmd.run:
+        {% if pillar.elife.env == 'prod' or pillar.elife.env == 'demo' or pillar.elife.env == 'end2end' %}
+        - name: composer1.0 --no-interaction install --classmap-authoritative --no-dev
+        {% elseif pillar.elife.env == 'ci' %}
+        - name: composer1.0 --no-interaction install --classmap-authoritative
+        {% else %}
         - name: composer1.0 --no-interaction install
+        {% endif %}
         - cwd: /srv/journal/
         - user: {{ pillar.elife.deploy_user.username }}
         # to correctly write into var/
         - umask: 002
+        - env:
+            - SYMFONY_ENV: {{ pillar.elife.env }}
         - require:
             - file: config-file
             - cmd: web-assets-symlink-cleaning
@@ -99,14 +107,6 @@ puli-publish-install:
         - user: {{ pillar.elife.deploy_user.username }}
         - require:
             - cmd: composer-install
-
-cache-cleaning:
-    cmd.run:
-        - name: bin/console cache:clear --env {{ pillar.elife.env }}
-        - cwd: /srv/journal
-        - user: {{ pillar.elife.deploy_user.username }}
-        - require:
-            - cmd: puli-publish-install
 
 journal-nginx-vhost:
     file.managed:


### PR DESCRIPTION
Currently untested, but this should improve Composer configuration, by:

- Optimising the class loader when not in development
- Not install development dependencies when not needed
- Setting the Symfony environment when executing `composer install` which should remove the need for the second cache clear.