### PR TITLE
Installing the PHP redis extension safely on new VMs

### DIFF
--- a/salt/journal/init.sls
+++ b/salt/journal/init.sls
@@ -5,15 +5,13 @@ maintenance-mode-start:
             - nginx-server-service
 
 journal-php-extensions:
-    pkg.installed:
-        - pkgs:
-            - php7.0-redis
+    cmd.run:
+        - name: apt-get install -y php7.0-redis
         - require:
             - php
             {% if pillar.elife.env in ['prod', 'demo', 'end2end', 'continuumtest', 'preview', 'continuumtestpreview'] %}
             - redis-server
             {% endif %}
-        - install_recommends: False
         - watch_in:
             - service: php-fpm
 


### PR DESCRIPTION
This was breaking on new instances. The direct apt-get command works more reliably, for some reason (problem must be in the `pkg.installed` Salt state).