### PR TITLE
Configuring default URL generation parameters

### DIFF
--- a/salt/journal/config/srv-journal-app-config-parameters.yml
+++ b/salt/journal/config/srv-journal-app-config-parameters.yml
@@ -17,3 +17,12 @@ parameters:
     crm_url: https://crm.elifesciences.org/crm/civicrm/
 
     disqus_domain: elifesciences-staging
+
+    # defaults for URL generation, should only be used in the CLI
+    {% if salt['elife.only_on_aws']() %}
+    router.request_context.host: {{ salt['elife.cfg']('project.full_hostname') }}
+    router.request_context.scheme: https
+    {% else %}
+    router.request_context.host: dev--journal.elifesciences.org 
+    router.request_context.scheme: http
+    {% endif %}

--- a/salt/journal/config/srv-journal-app-config-parameters.yml
+++ b/salt/journal/config/srv-journal-app-config-parameters.yml
@@ -18,11 +18,18 @@ parameters:
 
     disqus_domain: elifesciences-staging
 
-    # defaults for URL generation, should only be used in the CLI
-    {% if salt['elife.only_on_aws']() %}
+    # defaults for URL generation - host
+    {% if pillar.journal.get('base_url') %}
+    router.request_context.host: {{ pillar.journal.get('base_url') }}
+    {% elif salt['elife.only_on_aws']() %}
     router.request_context.host: {{ salt['elife.cfg']('project.full_hostname') }}
-    router.request_context.scheme: https
     {% else %}
     router.request_context.host: dev--journal.elifesciences.org 
+    {% endif %}
+    
+    # defaults for URL generation - scheme
+    {% if salt['elife.only_on_aws']() %}
+    router.request_context.scheme: https
+    {% else %}
     router.request_context.scheme: http
     {% endif %}

--- a/salt/journal/config/srv-journal-app-config-parameters.yml
+++ b/salt/journal/config/srv-journal-app-config-parameters.yml
@@ -19,8 +19,8 @@ parameters:
     disqus_domain: elifesciences-staging
 
     # defaults for URL generation - host
-    {% if pillar.journal.get('base_url') %}
-    router.request_context.host: {{ pillar.journal.get('base_url') }}
+    {% if pillar.journal.get('default_host') %}
+    router.request_context.host: {{ pillar.journal.get('default_host') }}
     {% elif salt['elife.only_on_aws']() %}
     router.request_context.host: {{ salt['elife.cfg']('project.full_hostname') }}
     {% else %}

--- a/salt/pillar/journal.sls
+++ b/salt/pillar/journal.sls
@@ -4,6 +4,7 @@ journal:
     api_key: key_for_authorizing_api_requests
     side_by_side_view_url: https://lens.elifesciences.org/
     observer_url: https://observer.elifesciences.org/
+    base_url: null
 
     secret: ThisTokenIsNotSoSecretChangeIt
 


### PR DESCRIPTION
To avoid configuring explicitly every environment, this would be the non-CDN version even where available; URL still will work.