### PR TITLE
Redirect developers.elifesciences.org

### DIFF
--- a/salt/journal/config/etc-nginx-sites-enabled-journal.conf
+++ b/salt/journal/config/etc-nginx-sites-enabled-journal.conf
@@ -1,9 +1,21 @@
+# temporary documentation website - just a blog post
 server {
+    server_name developers.elifesciences.org;
     {% if salt['elife.cfg']('project.elb') %}
     listen 80;
     {% else %}
     listen 80;
     listen 443 ssl;
+    {% endif %}
+    return 302 https://elifesciences.org/elife-news/inside-elife-resources-developers;
+}
+
+server {
+    {% if salt['elife.cfg']('project.elb') %}
+    listen 80 default_server;
+    {% else %}
+    listen 80 default_server;
+    listen 443 ssl default_server;
     {% endif %}
 
     {% if salt['elife.only_on_aws']() %}


### PR DESCRIPTION
Introduces default_server which we tried to avoid, but direct traffic should be stopped by firewalls and untrusted bad hosts should be stopped by Journal's PHP code