### PR TITLE
Quoting parameters since they contain % signs

### DIFF
--- a/salt/journal/config/srv-journal-app-config-parameters.yml
+++ b/salt/journal/config/srv-journal-app-config-parameters.yml
@@ -1,7 +1,8 @@
 parameters:
-    {% for name in ['secret', 'api_key', 'api_url', 'api_url_public', 'side_by_side_view_url', 'session_name', 'status_checks'] %}
-    {{ name }}: {{ pillar.journal.get(name) }}
+    {% for name in ['secret', 'api_key', 'api_url', 'api_url_public', 'side_by_side_view_url', 'session_name' ] %}
+    {{ name }}: '{{ pillar.journal.get(name) }}'
     {% endfor %}
+    status_checks: {{ pillar.journal.get(name) }}
 
     trusted_hosts: ['^(.+\.)?elifesciences.org$', 'localhost', '^10\.[0-9]+\.[0-9]+\.[0-9]+$']
 


### PR DESCRIPTION
PHPUnit was saying that
```
Not quoting the scalar "%api_url%" starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0: 1x
    1x in ArticleControllerTest::it_displays_an_article_page from test\eLife\Journal\Controller
```