### PR TITLE
Robots.txt only in production

### DIFF
--- a/salt/journal/config/etc-nginx-sites-enabled-journal.conf
+++ b/salt/journal/config/etc-nginx-sites-enabled-journal.conf
@@ -12,11 +12,11 @@ server {
     return 302 https://elifesciences.org/elife-news/inside-elife-resources-developers;
 }
 
-map $http_host $ifrobots {
+map $http_host $robots_disallow {
     hostnames;
 
-    default norobots;
-    elifesciences.org robots;
+    default "/";
+    elifesciences.org "";
 }
 
 server {

--- a/salt/journal/config/etc-nginx-sites-enabled-journal.conf
+++ b/salt/journal/config/etc-nginx-sites-enabled-journal.conf
@@ -12,6 +12,13 @@ server {
     return 302 https://elifesciences.org/elife-news/inside-elife-resources-developers;
 }
 
+map $http_host $ifrobots {
+    hostnames;
+
+    default norobots;
+    elifesciences.org robots;
+}
+
 server {
     {% if salt['elife.cfg']('project.elb') %}
     listen 80 default_server;
@@ -50,8 +57,11 @@ server {
     }
     {% endif %}
 
-    {# if pillar.elife.env != 'prod' #}
+    {% if pillar.elife.env == 'prod' %}
+    include /etc/nginx/traits.d/$ifrobots.conf;
+    {% else %}
     include /etc/nginx/traits.d/norobots.conf;
+    {% endif %}
 
     location ~ \..*/.*\.php$ {
         return 403;

--- a/salt/journal/config/etc-nginx-sites-enabled-journal.conf
+++ b/salt/journal/config/etc-nginx-sites-enabled-journal.conf
@@ -58,7 +58,7 @@ server {
     {% endif %}
 
     {% if pillar.elife.env == 'prod' %}
-    include /etc/nginx/traits.d/$ifrobots.conf;
+    include /etc/nginx/traits.d/robots.conf;
     {% else %}
     include /etc/nginx/traits.d/norobots.conf;
     {% endif %}

--- a/salt/journal/config/etc-nginx-traits.d-robots.conf
+++ b/salt/journal/config/etc-nginx-traits.d-robots.conf
@@ -1,6 +1,6 @@
 # http://www.robotstxt.org/robotstxt.html
-# allow everything
+# allow everything only on main hostanme
 location /robots.txt {
     add_header Content-Type text/plain;
-    return 200 "User-Agent: *\nDisallow: \n";
+    return 200 "User-Agent: *\nDisallow: $robots_disallow\n";
 }

--- a/salt/journal/config/etc-nginx-traits.d-robots.conf
+++ b/salt/journal/config/etc-nginx-traits.d-robots.conf
@@ -1,0 +1,6 @@
+# http://www.robotstxt.org/robotstxt.html
+# allow everything
+location /robots.txt {
+    add_header Content-Type text/plain;
+    return 200 "User-Agent: *\nDisallow: \n";
+}

--- a/salt/journal/init.sls
+++ b/salt/journal/init.sls
@@ -142,6 +142,18 @@ journal-nginx-redirect-existing-paths:
             - service: nginx-server-service
             - service: php-fpm
 
+journal-nginx-robots:
+    file.managed:
+        - name: /etc/nginx/traits.d/robots.conf
+        - source: salt://journal/config/etc-nginx-traits.d-robots.conf
+        - template: jinja
+        - require:
+            - nginx-config
+            - nginx-error-pages
+        - listen_in:
+            - service: nginx-server-service
+            - service: php-fpm
+
 journal-nginx-vhost:
     file.managed:
         - name: /etc/nginx/sites-enabled/journal.conf
@@ -151,6 +163,7 @@ journal-nginx-vhost:
             - nginx-config
             - nginx-error-pages
             - journal-nginx-redirect-existing-paths
+            - journal-nginx-robots
         - listen_in:
             - service: nginx-server-service
             - service: php-fpm


### PR DESCRIPTION
~Tried initially to include a different robots configuration depending on the hostname, but `include` is apparently executed at startup time so it can't use variables. Will try to improve it once this basic form is online.~

Scenarios:
- `journal--end2end` and similar: only `norobots.conf` is used from `builder-base-formula`
- `journal--prod` with `elifesciences.org` host: `robots.conf` is used and prints `Disallow: ` which means allow anything
- `journal--prod` with other hosts: `robots.conf` is used, but it prints `Disallow: /`