### PR TITLE
Redirect old hostnames

### DIFF
--- a/salt/journal/config/etc-nginx-sites-enabled-journal.conf
+++ b/salt/journal/config/etc-nginx-sites-enabled-journal.conf
@@ -12,6 +12,22 @@ server {
     return 302 https://elifesciences.org/elife-news/inside-elife-resources-developers;
 }
 
+server {
+    server_name www.elifesciences.org elife.elifesciences.org prod.elifesciences.org;
+    {% if salt['elife.cfg']('project.elb') %}
+    listen 80;
+    {% else %}
+    listen 80;
+    listen 443 ssl;
+    {% endif %}
+    {% if pillar.journal.default_host %}
+    {% set main_hostname = pillar.journal.default_host %} 
+    {% else %}
+    {% set main_hostname = pillar.elife.env + '--journal.elifesciences.org' %}
+    {% endif %}
+    return 301 https://{{ main_hostname }}$request_uri;
+}
+
 map $http_host $robots_disallow {
     hostnames;
 

--- a/salt/pillar/journal.sls
+++ b/salt/pillar/journal.sls
@@ -4,7 +4,7 @@ journal:
     api_key: key_for_authorizing_api_requests
     side_by_side_view_url: https://lens.elifesciences.org/
     observer_url: https://observer.elifesciences.org/
-    base_url: null
+    default_host: null
 
     gtm_id: null
     disqus_domain: elifesciences-staging


### PR DESCRIPTION
Such as elife.elifescience.org and similar ones. Uses `default_host` if specified, otherwise the standard autogenerated host name