### PR TITLE
Gulp runs without Redis

### DIFF
--- a/salt/journal/init.sls
+++ b/salt/journal/init.sls
@@ -100,8 +100,9 @@ journal-node-modules-manual-install:
             - journal-npm-install
 
 image-generation:
-    cmd.run:
-        - name: ./retrying-gulp.sh
+    cmd.script:
+        - name: retrying-gulp
+        - source: salt://journal/scripts/retrying-gulp-without-redis.sh
         - cwd: /srv/journal
         - user: {{ pillar.elife.deploy_user.username }}
         - require:

--- a/salt/journal/scripts/retrying-gulp-without-redis.sh
+++ b/salt/journal/scripts/retrying-gulp-without-redis.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+
+redis_present () {
+    test -e /etc/init.d/redis-server
+}
+
+if redis_present; then
+    sudo /etc/init.d/redis-server stop
+fi
+./retrying-gulp.sh
+if redis_present; then
+    sudo /etc/init.d/redis-server start
+fi
+# avoid exit code specified from the if failure
+exit 0


### PR DESCRIPTION
They both use lots of memory: the first one to run many parallel processes, the econd one as storage.

We have to check is Redis is present because on `dev` and `ci` it won't.