### PR TITLE
Parameterizing elifesciences.org

### DIFF
--- a/salt/journal/config/etc-nginx-sites-enabled-journal.conf
+++ b/salt/journal/config/etc-nginx-sites-enabled-journal.conf
@@ -1,38 +1,40 @@
-include /etc/nginx/traits.d/redirect-existing-paths.conf;
+{% if pillar.elife.domain == 'elifesciences.org' %}
+    include /etc/nginx/traits.d/redirect-existing-paths.conf;
 
-# temporary documentation website - just a blog post
-server {
-    server_name developers.elifesciences.org;
-    {% if salt['elife.cfg']('project.elb') %}
-    listen 80;
-    {% else %}
-    listen 80;
-    listen 443 ssl;
-    {% endif %}
-    return 302 https://elifesciences.org/elife-news/inside-elife-resources-developers;
-}
+    # temporary documentation website - just a blog post
+    server {
+        server_name developers.elifesciences.org;
+        {% if salt['elife.cfg']('project.elb') %}
+        listen 80;
+        {% else %}
+        listen 80;
+        listen 443 ssl;
+        {% endif %}
+        return 302 https://elifesciences.org/elife-news/inside-elife-resources-developers;
+    }
 
-server {
-    server_name www.elifesciences.org elife.elifesciences.org prod.elifesciences.org elifesciences.net e-lifesciences.org e-lifesciences.net elifejournal.net e-lifejournal.org e-lifejournal.com e-lifejournal.net elifejournal.org;
-    {% if salt['elife.cfg']('project.elb') %}
-    listen 80;
-    {% else %}
-    listen 80;
-    listen 443 ssl;
-    {% endif %}
-    {% if pillar.journal.default_host %}
-    {% set main_hostname = pillar.journal.default_host %} 
-    {% else %}
-    {% set main_hostname = pillar.elife.env + '--journal.elifesciences.org' %}
-    {% endif %}
-    return 301 https://{{ main_hostname }}$request_uri;
-}
+    server {
+        server_name www.elifesciences.org elife.elifesciences.org prod.elifesciences.org elifesciences.net e-lifesciences.org e-lifesciences.net elifejournal.net e-lifejournal.org e-lifejournal.com e-lifejournal.net elifejournal.org;
+        {% if salt['elife.cfg']('project.elb') %}
+        listen 80;
+        {% else %}
+        listen 80;
+        listen 443 ssl;
+        {% endif %}
+        {% if pillar.journal.default_host %}
+        {% set main_hostname = pillar.journal.default_host %} 
+        {% else %}
+        {% set main_hostname = pillar.elife.env + '--journal.elifesciences.org' %}
+        {% endif %}
+        return 301 https://{{ main_hostname }}$request_uri;
+    }
+{% endif %}
 
 map $http_host $robots_disallow {
     hostnames;
 
     default "/";
-    elifesciences.org "";
+    {{ pillar.elife.domain }} "";
 }
 
 server {
@@ -44,7 +46,7 @@ server {
     {% endif %}
 
     {% if salt['elife.only_on_aws']() %}
-        server_name .elifesciences.org;
+        server_name .{{ pillar.elife.domain }};
         if ($http_x_forwarded_proto = "http") {
             rewrite ^(.*)$ https://$host$1 permanent;
         }
@@ -54,6 +56,7 @@ server {
 
     root /srv/journal/web;
 
+    {% if pillar.elife.domain == 'elifesciences.org' %}
     rewrite '^/content(/elife)?/[0-9]{1,}/e([0-9]{5,})(v.)?(/.*)?$' '/articles/$2$3' permanent;
     rewrite '^/content(/elife)?/[0-9]{1,}/e([0-9]{5,})(v.)?(-download(.figures)?)?.[a-z0-9]+$' '/articles/$2$3' permanent;
     rewrite '^/content(/elife)?/early/[0-9]{4}/[0-9]{2}/[0-9]{2}/eLife.([0-9]{5,})(\..*)?$' '/articles/$2' permanent;
@@ -61,6 +64,7 @@ server {
     if ($new_uri) {
         return 301 $new_uri;
     }
+    {% endif %}
 
     ## for accessing it with Selenium
     {% if pillar.elife.env == 'dev' %}

--- a/salt/journal/config/srv-journal-app-config-parameters.yml
+++ b/salt/journal/config/srv-journal-app-config-parameters.yml
@@ -7,7 +7,7 @@ parameters:
     {% endif %}
     {% endfor %}
 
-    trusted_hosts: ['^(.+\.)?elifesciences.org$', 'localhost', '^10\.[0-9]+\.[0-9]+\.[0-9]+$']
+    trusted_hosts: ['^(.+\.)?{{ pillar.elife.domain }}$', 'localhost', '^10\.[0-9]+\.[0-9]+\.[0-9]+$']
 
     redis_cache: redis://localhost
 
@@ -18,7 +18,7 @@ parameters:
     mailer_password: {{ pillar.journal.mailer.password }}
     mailer_encryption: {{ pillar.journal.mailer.encryption }}
 
-    crm_url: https://crm.elifesciences.org/crm/civicrm/
+    crm_url: https://crm.thedailybugle.org/crm/civicrm/
 
     # defaults for URL generation - host
     {% if pillar.journal.get('default_host') %}
@@ -26,7 +26,7 @@ parameters:
     {% elif salt['elife.only_on_aws']() %}
     router.request_context.host: {{ salt['elife.cfg']('project.full_hostname') }}
     {% else %}
-    router.request_context.host: dev--journal.elifesciences.org 
+    router.request_context.host: dev--journal.{{ pillar.elife.domain }} 
     {% endif %}
     
     # defaults for URL generation - scheme

--- a/salt/journal/config/srv-journal-behat.yml
+++ b/salt/journal/config/srv-journal-behat.yml
@@ -7,7 +7,7 @@ default:
             {% if pillar.elife.env == 'dev' %}
             base_url: http://localhost/app_test.php/
             {% else %}
-            base_url: http://{{ pillar.elife.env }}--journal.elifesciences.org/
+            base_url: http://{{ pillar.elife.env }}--journal.{{ pillar.elife.domain}}/
             {% endif %}
         Behat\Symfony2Extension:
             kernel:

--- a/salt/pillar/journal.sls
+++ b/salt/pillar/journal.sls
@@ -1,5 +1,5 @@
 journal:
-    api_url: https://api.elifesciences.org/
+    api_url: https://prod--cdn-gateway.elifesciences.org/
     api_url_public: '%api_url%'
     api_key: key_for_authorizing_api_requests
     side_by_side_view_url: https://lens.elifesciences.org/


### PR DESCRIPTION
At least in all places where it's strictly needed. This serves the purpose of making journal work on thedailybugle.org

`pillar.elife.domain` has been introduced in builder-base-formula and builder-private

Also, a bunch of things are not needed outside elife so we don't put them inside the nginx configuration.