### PR TITLE
[WIP] ELPP-2940 Add strict-transport-security header

### DIFF
--- a/salt/journal/config/etc-nginx-sites-enabled-journal.conf
+++ b/salt/journal/config/etc-nginx-sites-enabled-journal.conf
@@ -86,14 +86,20 @@ server {
     {% endif %}
 
     location ~ \..*/.*\.php$ {
+        include /etc/nginx/traits.d/strict-transport-security.conf;
+
         return 403;
     }
 
     location / {
+        include /etc/nginx/traits.d/strict-transport-security.conf;
+
         try_files $uri /app_{{ pillar.elife.env }}.php$is_args$query_string;
     }
 
     location ~ ^/app_{{ pillar.elife.env }}\.php(/|$) {
+        include /etc/nginx/traits.d/strict-transport-security.conf;
+
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME $request_filename;
@@ -112,20 +118,28 @@ server {
     }
 
     location ~ /app_.*.php$ {
+        include /etc/nginx/traits.d/strict-transport-security.conf;
+
         return 404;
     }
 
     location /assets {
+        include /etc/nginx/traits.d/strict-transport-security.conf;
+
         add_header Cache-Control "public, max-age={{ 60 * 60 * 24 * 365 }}, immutable";
     }
 
     location = /rss/recent.xml {
+        include /etc/nginx/traits.d/strict-transport-security.conf;
+
         proxy_pass {{ pillar.journal.observer_url }}/report/latest-articles.rss;
         proxy_connect_timeout 5s;
         proxy_read_timeout 30s;
     }
 
     location = /rss/ahead.xml {
+        include /etc/nginx/traits.d/strict-transport-security.conf;
+
         proxy_pass {{ pillar.journal.observer_url }}/report/upcoming-articles.rss;
         proxy_connect_timeout 5s;
         proxy_read_timeout 30s;

--- a/salt/journal/config/etc-nginx-traits.d-strict-transport-security.conf
+++ b/salt/journal/config/etc-nginx-traits.d-strict-transport-security.conf
@@ -1,0 +1,9 @@
+if ($https) {
+    add_header Strict-Transport-Security "max-age={{ 60 * 60 * 24 * 365 }}; includeSubDomains";
+}
+
+{% if salt['elife.cfg']('project.elb') %}
+if ($http_x_forwarded_proto = "https") {
+    add_header Strict-Transport-Security "max-age={{ 60 * 60 * 24 * 365 }}; includeSubDomains";
+}
+{% endif %}

--- a/salt/journal/init.sls
+++ b/salt/journal/init.sls
@@ -155,6 +155,17 @@ journal-nginx-robots:
             - service: nginx-server-service
             - service: php-fpm
 
+journal-nginx-strict-transport-security:
+    file.managed:
+        - name: /etc/nginx/traits.d/strict-transport-security.conf
+        - source: salt://journal/config/etc-nginx-traits.d-strict-transport-security.conf
+        - template: jinja
+        - require:
+            - nginx-config
+        - listen_in:
+            - service: nginx-server-service
+            - service: php-fpm
+
 journal-nginx-vhost:
     file.managed:
         - name: /etc/nginx/sites-enabled/journal.conf
@@ -165,6 +176,7 @@ journal-nginx-vhost:
             - nginx-error-pages
             - journal-nginx-redirect-existing-paths
             - journal-nginx-robots
+            - journal-nginx-strict-transport-security
         - listen_in:
             - service: nginx-server-service
             - service: php-fpm


### PR DESCRIPTION
Refs https://github.com/elifesciences/journal/pull/637.

The `if` statement makes this complicated (has to be duplicated in every `location` directive). I'm tempted to say keep this in the application. It does mean that it wouldn't apply to assets, but that doesn't feel like a problem (as soon as you view an application-produced response the header will apply to the whole domain).