### PR TITLE
api-dummy working copy and virtual host

### DIFF
--- a/salt/example.top
+++ b/salt/example.top
@@ -17,7 +17,6 @@ base:
         - journal
         - elife.proofreader-php
         {% if pillar.journal.critical_css %}
-        - elife.redis-server # TODO: remove, only for local experimentation
         - api-dummy
         - journal.api-dummy
         {% endif %}

--- a/salt/example.top
+++ b/salt/example.top
@@ -16,3 +16,8 @@ base:
         - journal.curl-7-36
         - journal
         - elife.proofreader-php
+        {% if pillar.elife.env in ['dev', 'end2end', 'prod'] %}
+        - elife.redis-server
+        - api-dummy
+        - journal.api-dummy
+        {% endif %}

--- a/salt/example.top
+++ b/salt/example.top
@@ -16,8 +16,8 @@ base:
         - journal.curl-7-36
         - journal
         - elife.proofreader-php
-        {% if pillar.elife.env in ['dev', 'end2end', 'prod'] %}
-        - elife.redis-server
+        {% if pillar.journal.critical_css %}
+        - elife.redis-server # TODO: remove, only for local experimentation
         - api-dummy
         - journal.api-dummy
         {% endif %}

--- a/salt/journal/api-dummy.sls
+++ b/salt/journal/api-dummy.sls
@@ -1,0 +1,10 @@
+api-dummy-nginx-vhost:
+    file.managed:
+        - name: /etc/nginx/sites-enabled/api-dummy.conf
+        - source: salt://journal/config/etc-nginx-sites-enabled-api-dummy.conf
+        - require:
+            - api-dummy-composer-install
+            - journal-nginx-vhost-local-demo
+        - listen_in:
+            - service: nginx-server-service
+            - service: php-fpm

--- a/salt/journal/api-dummy.sls
+++ b/salt/journal/api-dummy.sls
@@ -2,9 +2,5 @@ api-dummy-nginx-vhost:
     file.managed:
         - name: /etc/nginx/sites-enabled/api-dummy.conf
         - source: salt://journal/config/etc-nginx-sites-enabled-api-dummy.conf
-        - require:
-            - api-dummy-composer-install
-            - journal-nginx-vhost-local-demo
         - listen_in:
             - service: nginx-server-service
-            - service: php-fpm

--- a/salt/journal/config/etc-nginx-sites-enabled-api-dummy.conf
+++ b/salt/journal/config/etc-nginx-sites-enabled-api-dummy.conf
@@ -1,0 +1,23 @@
+server {
+    listen 8080;
+    server_name localhost;
+    root /srv/api-dummy/web;
+
+    location / {
+        try_files $uri /index.php$is_args$args;
+    }
+
+    location ~ ^/index\.php(/|$) {
+        fastcgi_split_path_info ^(.+\.php)(/.*)$;
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_pass unix:/var/run/php/php7.0-fpm.sock;
+    }
+
+    location ~ \.php$ {
+        return 404;
+    }
+
+    access_log /var/log/nginx/api-dummy.access.log combined_with_time;
+    error_log /var/log/nginx/api-dummy.error.log notice;
+}

--- a/salt/journal/config/etc-nginx-sites-enabled-api-dummy.conf
+++ b/salt/journal/config/etc-nginx-sites-enabled-api-dummy.conf
@@ -1,5 +1,5 @@
 server {
-    listen 8080;
+    listen 8081;
     server_name localhost;
     root /srv/api-dummy/web;
 

--- a/salt/journal/config/etc-nginx-sites-enabled-journal-local-demo.conf
+++ b/salt/journal/config/etc-nginx-sites-enabled-journal-local-demo.conf
@@ -19,7 +19,6 @@ server {
         fastcgi_param SCRIPT_FILENAME $request_filename;
         fastcgi_param DOCUMENT_ROOT $realpath_root;
         fastcgi_param ENVIRONMENT_NAME {{ environment_name }};
-        fastcgi_param SYMFONY__API_URL http://localhost:8081;
         fastcgi_pass unix:/var/php-fpm.sock;
         internal;
     }

--- a/salt/journal/config/etc-nginx-sites-enabled-journal-local-demo.conf
+++ b/salt/journal/config/etc-nginx-sites-enabled-journal-local-demo.conf
@@ -27,6 +27,6 @@ server {
         return 404;
     }
 
-    access_log /var/log/nginx/journal-dummy.access.log combined_with_time;
-    error_log /var/log/nginx/journal-dummy.error.log notice;
+    access_log /var/log/nginx/journal-local-demo.access.log combined_with_time;
+    error_log /var/log/nginx/journal-local-demo.error.log notice;
 }

--- a/salt/journal/config/etc-nginx-sites-enabled-journal-local-demo.conf
+++ b/salt/journal/config/etc-nginx-sites-enabled-journal-local-demo.conf
@@ -1,7 +1,7 @@
 {% set environment_name = 'demo' %}
 
 server {
-    listen 8081;
+    listen 8080;
     server_name localhost;
     root /srv/journal/web;
 
@@ -19,7 +19,7 @@ server {
         fastcgi_param SCRIPT_FILENAME $request_filename;
         fastcgi_param DOCUMENT_ROOT $realpath_root;
         fastcgi_param ENVIRONMENT_NAME {{ environment_name }};
-        fastcgi_param SYMFONY__API_URL http://localhost:8080;
+        fastcgi_param SYMFONY__API_URL http://localhost:8081;
         fastcgi_pass unix:/var/php-fpm.sock;
         internal;
     }

--- a/salt/journal/config/etc-nginx-sites-enabled-journal-local-demo.conf
+++ b/salt/journal/config/etc-nginx-sites-enabled-journal-local-demo.conf
@@ -19,6 +19,7 @@ server {
         fastcgi_param SCRIPT_FILENAME $request_filename;
         fastcgi_param DOCUMENT_ROOT $realpath_root;
         fastcgi_param ENVIRONMENT_NAME {{ environment_name }};
+        fastcgi_param SYMFONY__API_URL http://localhost:8080;
         fastcgi_pass unix:/var/php-fpm.sock;
         internal;
     }

--- a/salt/journal/init.sls
+++ b/salt/journal/init.sls
@@ -1,5 +1,3 @@
-{% set environments_with_critical_css = ['dev', 'end2end', 'prod'] %}
-
 maintenance-mode-start:
     cmd.run:
         - name: |
@@ -162,7 +160,7 @@ journal-nginx-vhost:
             - service: nginx-server-service
             - service: php-fpm
 
-{% if pillar.elife.env in environments_with_critical_css %}
+{% if pillar.journal.critical_css %}
 journal-nginx-vhost-local-demo:
     file.managed:
         - name: /etc/nginx/sites-enabled/journal-local-demo.conf
@@ -188,7 +186,7 @@ running-gulp:
             - journal-node-modules-manual-install
             - composer-install
 
-{% if pillar.elife.env in environments_with_critical_css %}
+{% if pillar.journal.critical_css %}
 local-demo-cache-clear:
     cmd.run:
         - name: bin/console cache:clear --env=demo --no-warmup

--- a/salt/journal/init.sls
+++ b/salt/journal/init.sls
@@ -161,7 +161,7 @@ journal-nginx-vhost:
             - service: php-fpm
 
 {% if pillar.journal.critical_css %}
-journal-nginx-vhost-local-demo:
+journal-local-demo-nginx-vhost:
     file.managed:
         - name: /etc/nginx/sites-enabled/journal-local-demo.conf
         - source: salt://journal/config/etc-nginx-sites-enabled-journal-local-demo.conf

--- a/salt/pillar/journal.sls
+++ b/salt/pillar/journal.sls
@@ -27,3 +27,7 @@ journal:
 
     status_checks:
         Articles: articles
+
+api_dummy:
+    standalone: False
+    pinned_revision_file: /srv/journal/api-dummy.sha1

--- a/salt/pillar/journal.sls
+++ b/salt/pillar/journal.sls
@@ -28,7 +28,7 @@ journal:
     status_checks:
         Articles: articles
 
-    critical_css: True # TODO: disable in dev
+    critical_css: False
 
 api_dummy:
     standalone: False

--- a/salt/pillar/journal.sls
+++ b/salt/pillar/journal.sls
@@ -28,6 +28,8 @@ journal:
     status_checks:
         Articles: articles
 
+    critical_css: True # TODO: disable in dev
+
 api_dummy:
     standalone: False
     pinned_revision_file: /srv/journal/api-dummy.sha1


### PR DESCRIPTION
Current status is api-dummy is deployed, but not actually used as journal-local-demo points to the `prod` API.