### PR TITLE
Add packages required by Chrome headless

### DIFF
--- a/salt/journal/critical-css.sls
+++ b/salt/journal/critical-css.sls
@@ -1,3 +1,10 @@
+npm-critical-css-build-dependencies:
+    pkg.installed:
+        - pkgs:
+            - libgconf-2-4
+            - libnss3
+            - libxss1
+
 generate-critical-css:
     cmd.run:
         - name: node_modules/.bin/gulp critical-css:generate
@@ -8,6 +15,7 @@ generate-critical-css:
             - api-dummy-nginx-vhost
             - journal-local-demo-cache-clean
             - journal-local-demo-nginx-vhost
+            - npm-critical-css-build-dependencies
             - php-fpm
         - require_in:
             - cmd: maintenance-mode-end


### PR DESCRIPTION
For https://github.com/elifesciences/journal/pull/789.

Full list in https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md, but this was enough for it to work.