### PR TITLE
ELPP-3223 Full package list needed for Chrome headless

### DIFF
--- a/salt/journal/critical-css.sls
+++ b/salt/journal/critical-css.sls
@@ -1,9 +1,45 @@
 npm-critical-css-build-dependencies:
     pkg.installed:
         - pkgs:
+            # from https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md
+            - gconf-service
+            - libasound2
+            - libatk1.0-0
+            - libc6
+            - libcairo2
+            - libcups2
+            - libdbus-1-3
+            - libexpat1
+            - libfontconfig1
+            - libgcc1
             - libgconf-2-4
-            - libnss3
+            - libgdk-pixbuf2.0-0
+            - libglib2.0-0
+            - libgtk-3-0
+            - libnspr4
+            - libpango-1.0-0
+            - libpangocairo-1.0-0
+            - libstdc++6
+            - libx11-6
+            - libx11-xcb1
+            - libxcb1
+            - libxcomposite1
+            - libxcursor1
+            - libxdamage1
+            - libxext6
+            - libxfixes3
+            - libxi6
+            - libxrandr2
+            - libxrender1
             - libxss1
+            - libxtst6
+            - ca-certificates
+            - fonts-liberation
+            - libappindicator1
+            - libnss3
+            - lsb-release
+            - xdg-utils
+            - wget
 
 generate-critical-css:
     cmd.run:


### PR DESCRIPTION
#34 still fails on end2end (can't reproduce by mimicking end2end in vagrant).