### PR TITLE
Avoid bootstrapping Symfony when cleaning the local demo's cache

### DIFF
--- a/salt/journal/local-demo.sls
+++ b/salt/journal/local-demo.sls
@@ -56,5 +56,7 @@ journal-local-demo-cache-clean:
         - name: composer run post-install-cmd
         - cwd: /srv/journal-local-demo
         - user: {{ pillar.elife.deploy_user.username }}
+        - env:
+            - SYMFONY_ENV: demo
         - require:
             - journal-local-demo-parameters

--- a/salt/journal/local-demo.sls
+++ b/salt/journal/local-demo.sls
@@ -53,7 +53,7 @@ journal-local-demo-parameters:
 
 journal-local-demo-cache-clean:
     cmd.run:
-        - name: bin/console cache:clear --env=demo
+        - name: composer run post-install-cmd
         - cwd: /srv/journal-local-demo
         - user: {{ pillar.elife.deploy_user.username }}
         - require:


### PR DESCRIPTION
https://github.com/elifesciences/journal/pull/806 fails because the local demo's cache clearer seems to conflict when changing Symfony version. This changes it to run the post-install commands, which includes a cache clear (so should avoid bootstrapping the app, but also avoids using `rm -rf`).