### PR TITLE
Force Symfony cache cleans

### DIFF
--- a/salt/journal/critical-css.sls
+++ b/salt/journal/critical-css.sls
@@ -47,11 +47,7 @@ generate-critical-css:
         - cwd: /srv/journal
         - user: {{ pillar.elife.deploy_user.username }}
         - require:
-            - api-dummy-composer-install
-            - api-dummy-nginx-vhost
-            - journal-local-demo-cache-clean
-            - journal-local-demo-nginx-vhost
+            - journal-local-demo-ready
             - npm-critical-css-build-dependencies
-            - php-fpm
         - require_in:
             - cmd: maintenance-mode-end

--- a/salt/journal/init.sls
+++ b/salt/journal/init.sls
@@ -71,6 +71,14 @@ var-directory:
         - require:
             - file: var-directory
 
+journal-cache-clean:
+    cmd.run:
+        - name: rm -rf var/cache/
+        - cwd: /srv/journal/
+        - user: {{ pillar.elife.deploy_user.username }}
+        - require:
+            - var-directory
+
 npm-build-dependencies:
     pkg.installed:
         - pkgs:
@@ -116,7 +124,7 @@ composer-install:
             - COMPOSER_DISCARD_CHANGES: 'true'
         - require:
             - file: config-file
-            - cmd: var-directory
+            - journal-cache-clean
             - journal-php-extensions
 
 journal-nginx-redirect-existing-paths:

--- a/salt/journal/local-demo.sls
+++ b/salt/journal/local-demo.sls
@@ -53,10 +53,8 @@ journal-local-demo-parameters:
 
 journal-local-demo-cache-clean:
     cmd.run:
-        - name: composer run post-install-cmd
+        - name: rm -rf var/cache/
         - cwd: /srv/journal-local-demo
         - user: {{ pillar.elife.deploy_user.username }}
-        - env:
-            - SYMFONY_ENV: demo
         - require:
-            - journal-local-demo-parameters
+            - journal-local-demo-separate-folder

--- a/salt/journal/local-demo.sls
+++ b/salt/journal/local-demo.sls
@@ -58,3 +58,14 @@ journal-local-demo-cache-clean:
         - user: {{ pillar.elife.deploy_user.username }}
         - require:
             - journal-local-demo-separate-folder
+
+journal-local-demo-ready:
+    cmd.run:
+        - name: echo "journal-local-demo is ready"
+        - require:
+            - api-dummy-composer-install
+            - api-dummy-nginx-vhost
+            - journal-local-demo-cache-clean
+            - journal-local-demo-parameters
+            - nginx-server-service
+            - php-fpm


### PR DESCRIPTION
It still seems like a PR upgrading Symfony can create problems for builds that upgrade (eg https://alfred.elifesciences.org/blue/organizations/jenkins/pull-requests-projects%2Fjournal/detail/PR-806/5/pipeline) or downgrades (ie separate PR, eg https://alfred.elifesciences.org/blue/organizations/jenkins/pull-requests-projects%2Fjournal/detail/PR-809/1/pipeline)