### PR TITLE
Support old/new ElastiCache CloudFormation outputs

### DIFF
--- a/salt/journal/config/srv-journal-app-config-parameters.yml
+++ b/salt/journal/config/srv-journal-app-config-parameters.yml
@@ -1,11 +1,13 @@
-{% set on_elasticache = salt['elife.cfg']('cfn.outputs.ElastiCacheHost') %}
 {% set standard_keys = ['secret', 'api_key', 'api_url', 'api_url_public', 'side_by_side_view_url', 'session_name', 'status_checks', 'gtm_id', 'disqus_domain', 'oauth2_client_id', 'oauth2_client_secret', 'hypothesis_api', 'hypothesis_authority', 'hypothesis_client_id', 'hypothesis_client_secret', 'feature_can_view_webp_countries']  %}
 
 parameters:
     {% if pillar.journal.get('redis') == false %}
     redis: null
-    {% elif on_elasticache %}
+    {% elif salt['elife.cfg']('cfn.outputs.ElastiCacheHost') %}
     {% set remote_redis = "redis://" + salt['elife.cfg']('cfn.outputs.ElastiCacheHost') + ":" + salt['elife.cfg']('cfn.outputs.ElastiCachePort') %}
+    redis: {{ remote_redis }}
+    {% elif salt['elife.cfg']('cfn.outputs.ElastiCacheHost1') %}
+    {% set remote_redis = "redis://" + salt['elife.cfg']('cfn.outputs.ElastiCacheHost1') + ":" + salt['elife.cfg']('cfn.outputs.ElastiCachePort1') %}
     redis: {{ remote_redis }}
     {% else %}
     {% do standard_keys.extend(['redis']) %}


### PR DESCRIPTION
`end2end` (and later `prod`) won't see the new ElastiCache configuration until this pull request is in. Can't really be fully tested in the formula build, as it doesn't have a variant with ElastiCache.