### PR TITLE
Fix YAML indentation

### DIFF
--- a/salt/journal/config/srv-journal-app-config-parameters.yml
+++ b/salt/journal/config/srv-journal-app-config-parameters.yml
@@ -18,7 +18,8 @@ parameters:
     {% endif %}
 
     {% for name in standard_keys %}
-    {{ name }}: {{ pillar.journal.get(name)|yaml }}
+    {{ name }}:
+        {{ pillar.journal.get(name)|yaml(False)|indent(8) }}
     {% endfor %}
 
     trusted_hosts: ['^(.+\.)?{{ pillar.elife.domain }}$', 'localhost', '^10\.[0-9]+\.[0-9]+\.[0-9]+$', '^172\.(16|17|18|19|2[0-9]|30|31)\.[0-9]+\.[0-9]+$', '^192.168\.[0-9]+\.[0-9]+$']


### PR DESCRIPTION
#43 broke in end2end as a long object wrapped, causing incorrect indentation.

This uses the `indent` filter to add the correct indent of any following lines, but also puts the value on a new line to avoid any inconsistencies, and to avoid having to calculate the indent (seems to work fine with any type). This also makes any diffs cleaner. 