### PR TITLE
Update packages for Chromium

### DIFF
--- a/salt/journal/critical-css.sls
+++ b/salt/journal/critical-css.sls
@@ -1,5 +1,5 @@
 npm-critical-css-build-dependencies:
-    pkg.installed:
+    pkg.latest:
         - pkgs:
             # from https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md
             - gconf-service


### PR DESCRIPTION
Seems that fresh instances get older versions that don't work (where as long-running instances have been updated), hence problems in #45.

Might also fix #36.