### PR TITLE
Remove ported hostnames

### DIFF
--- a/salt/journal/config/etc-nginx-sites-available-journal.conf
+++ b/salt/journal/config/etc-nginx-sites-available-journal.conf
@@ -1,22 +1,6 @@
 {# todo: mass redirects are useful in general. lets find a way of supporting this that isn't elife-specific #}
 {% if pillar.elife.domain == 'elifesciences.org' %}
     include /etc/nginx/traits.d/redirect-existing-paths.conf;
-
-    server {
-        server_name www.elifesciences.org elife.elifesciences.org prod.elifesciences.org elifesciences.net e-lifesciences.org e-lifesciences.net elifejournal.net e-lifejournal.org e-lifejournal.com e-lifejournal.net elifejournal.org;
-        {% if salt['elife.cfg']('project.elb') %}
-        listen 80;
-        {% else %}
-        listen 80;
-        listen 443 ssl;
-        {% endif %}
-        {% if pillar.journal.default_host %}
-        {% set main_hostname = pillar.journal.default_host %} 
-        {% else %}
-        {% set main_hostname = pillar.elife.env + '--journal.elifesciences.org' %}
-        {% endif %}
-        return 301 https://{{ main_hostname }}$request_uri;
-    }
 {% endif %}
 
 {# these are subdomain => canonical domain + path redirects #}


### PR DESCRIPTION
These hostnames resolve to a CDN backed by redirects--prod. They should never get to this nginx.