### PR TITLE
ELPP-3393 Allow use of X-Forwarded-Host for robots.txt

### DIFF
--- a/salt/journal/config/etc-nginx-sites-available-journal.conf
+++ b/salt/journal/config/etc-nginx-sites-available-journal.conf
@@ -20,10 +20,10 @@ server {
 }{% endfor %}
 
 
-# TODO: simplify to use only Elife-Orig-Host after move to Fastly
+# TODO: simplify to use only X-Forwarded-Host after move to Fastly
 # right now, displays the allowing robots.txt when at
 # least one of the two headers correspond to the canonical host
-map "$http_host:$http_elife_orig_host" $robots_disallow {
+map "$http_host:$http_x_forwarded_host" $robots_disallow {
     default "/";
     "~^elifesciences.org:.*$" "";
     "~^.*:elifesciences.org$" "";


### PR DESCRIPTION
`robots.txt` is the only dependency here, simple rename from the previous custom header.