### PR TITLE
Separate build/ copies from rsync

### DIFF
--- a/salt/journal/local-demo.sls
+++ b/salt/journal/local-demo.sls
@@ -33,7 +33,8 @@ journal-local-demo-separate-folder:
 
     cmd.run:
         - name: |
-            rsync -a --exclude='.git' --exclude 'app/config/parameters.yml' --include 'build/assets/patterns/js/elife-loader.js' --include 'build/rev-manifest.json' --exclude 'build/*' --exclude 'node_modules' --include 'var/.gitkeep' --exclude 'var/*' --delete /srv/journal/ /srv/journal-local-demo
+            rsync -a --exclude='.git' --exclude 'app/config/parameters.yml' --exclude 'build/*' --exclude 'node_modules' --include 'var/.gitkeep' --exclude 'var/*' --delete /srv/journal/ /srv/journal-local-demo
+            cp --parents build/assets/patterns/js/elife-loader.js build/rev-manifest.json /srv/journal-local-demo
             cp --parents build/critical-css/.gitkeep /srv/journal-local-demo
         - cwd: /srv/journal
         - user: {{ pillar.elife.deploy_user.username }}


### PR DESCRIPTION
Multiple `--include` and `--exclude` patterns lead to conflicts, so separating into a `cp` to fix the creation of `elife-loader.js`