### PR TITLE
ELPP-3732 Fix redirect scheme

### DIFF
--- a/salt/journal/config/etc-nginx-sites-available-journal.conf
+++ b/salt/journal/config/etc-nginx-sites-available-journal.conf
@@ -28,7 +28,7 @@ server {
         listen 443 ssl;
     {% endif %}
     # temporary redirect. TODO: change to permanent
-    return 302 https://{{ public_host }}{{ redirect_path }};
+    return 302 {{ public_scheme }}://{{ public_host }}{{ redirect_path }};
 }{% endfor %}
 
 

--- a/salt/journal/config/etc-nginx-sites-available-journal.conf
+++ b/salt/journal/config/etc-nginx-sites-available-journal.conf
@@ -5,7 +5,12 @@
 {% else %}
     {% set public_host = 'dev--journal.elifesciences.org' %}
 {% endif %}
-{% set public_scheme = 'https' %}
+
+{% if salt['elife.only_on_aws']() %}
+    {% set public_scheme = 'https' %}
+{% else %}
+    {% set public_scheme = 'http' %}
+{% endif %}
 
 {# todo: mass redirects are useful in general. lets find a way of supporting this that isn't elife-specific #}
 include /etc/nginx/traits.d/redirect-existing-paths.conf;

--- a/salt/journal/config/etc-nginx-sites-available-journal.conf
+++ b/salt/journal/config/etc-nginx-sites-available-journal.conf
@@ -5,6 +5,7 @@
 {% else %}
     {% set public_host = 'dev--journal.elifesciences.org' %}
 {% endif %}
+{% set public_scheme = 'https' %}
 
 {# todo: mass redirects are useful in general. lets find a way of supporting this that isn't elife-specific #}
 include /etc/nginx/traits.d/redirect-existing-paths.conf;
@@ -62,17 +63,17 @@ server {
 
     root /srv/journal/web;
 
-    rewrite '^/content(/elife)?/[0-9]{1,}/e([0-9]{5,})(v.)?(/.*)?$' '$scheme://{{ public_host }}/articles/$2$3' permanent;
-    rewrite '^/content(/elife)?/[0-9]{1,}/e([0-9]{5,})(v.)?(-download(.figures)?)?.[a-z0-9]+$' '$scheme://{{ public_host }}/articles/$2$3' permanent;
-    rewrite '^/content(/elife)?/early/[0-9]{4}/[0-9]{2}/[0-9]{2}/eLife.([0-9]{5,})(\..*)?$' '$scheme://{{ public_host }}/articles/$2' permanent;
-    rewrite '^/(.*)/$' '$scheme://{{ public_host }}/$1' permanent;
-    rewrite '^/About$' '$scheme://{{ public_host }}/about' permanent;
-    rewrite '^/Community$' '$scheme://{{ public_host }}/community' permanent;
-    rewrite '^/Events$' '$scheme://{{ public_host }}/events' permanent;
-    rewrite '^/Labs$' '$scheme://{{ public_host }}/labs' permanent;
+    rewrite '^/content(/elife)?/[0-9]{1,}/e([0-9]{5,})(v.)?(/.*)?$' '{{ public_scheme }}://{{ public_host }}/articles/$2$3' permanent;
+    rewrite '^/content(/elife)?/[0-9]{1,}/e([0-9]{5,})(v.)?(-download(.figures)?)?.[a-z0-9]+$' '{{ public_scheme }}://{{ public_host }}/articles/$2$3' permanent;
+    rewrite '^/content(/elife)?/early/[0-9]{4}/[0-9]{2}/[0-9]{2}/eLife.([0-9]{5,})(\..*)?$' '{{ public_scheme }}://{{ public_host }}/articles/$2' permanent;
+    rewrite '^/(.*)/$' '{{ public_scheme }}://{{ public_host }}/$1' permanent;
+    rewrite '^/About$' '{{ public_scheme }}://{{ public_host }}/about' permanent;
+    rewrite '^/Community$' '{{ public_scheme }}://{{ public_host }}/community' permanent;
+    rewrite '^/Events$' '{{ public_scheme }}://{{ public_host }}/events' permanent;
+    rewrite '^/Labs$' '{{ public_scheme }}://{{ public_host }}/labs' permanent;
 
     if ($new_uri) {
-        return 301 $scheme://{{ public_host }}$new_uri;
+        return 301 {{ public_scheme }}://{{ public_host }}$new_uri;
     }
 
     ## for accessing it with Selenium


### PR DESCRIPTION
Follow up to #70, which gets the host right but sees the scheme as just `http`.

Thinking it should be possible to use the `X-Forwarded-*` headers here though.