### PR TITLE
Handle multiple X-Forwarded-Host values

### DIFF
--- a/salt/journal/config/etc-nginx-sites-available-journal.conf
+++ b/salt/journal/config/etc-nginx-sites-available-journal.conf
@@ -36,17 +36,13 @@ server {
 }{% endfor %}
 
 map $http_x_forwarded_host $robots_disallow {
-    hostnames;
-
     default "/";
-    {{ pillar.elife.domain }} "";
+    "~^(?<first_host>(?:[^,]+\.)?{{ pillar.elife.domain|regex_escape }})\s*(?:,|$)" "";
 }
 
 map $http_x_forwarded_host $http_x_forwarded_host_filtered {
-    hostnames;
-
     default "";
-    .{{ pillar.elife.domain }} $http_x_forwarded_host;
+    "~^(?<first_host>(?:[^,]+\.)?{{ pillar.elife.domain|regex_escape }})\s*(?:,|$)" $first_host;
 }
 
 server {


### PR DESCRIPTION
Currently Fastly sends duplicates `X-Forwarded-Host` values.

Nginx's `hostnames` appears to only work with third-level domains when there are multiple values.

So:

- `X-Forwarded-Host: foo.elifesciences.org, foo.elifesciences.org` works
- `X-Forwarded-Host: elifesciences.org, elifesciences.org` doesn't

This uses regex to capture the first value and check that. (This should be reverted when only one value is sent.)