### PR TITLE
Don't index download links

### DIFF
--- a/salt/journal/config/etc-nginx-traits.d-robots.conf
+++ b/salt/journal/config/etc-nginx-traits.d-robots.conf
@@ -2,5 +2,5 @@
 # allow everything only on main hostanme
 location /robots.txt {
     add_header Content-Type text/plain;
-    return 200 "User-Agent: *\nDisallow: $robots_disallow\n";
+    return 200 "User-Agent: *\nDisallow: $robots_disallow\nDisallow: /download/\n";
 }


### PR DESCRIPTION
According to the logs, Googlebot (at least) is following the links to download files (which are streamed through Journal to add the `Content-Disposition` header). Don't think it's of any use to them, so we should stop bots from going to `/download/` paths.