### PR TITLE
Include redis service if external host not configured

### DIFF
--- a/salt/journal/config/srv-journal-docker-compose.yml
+++ b/salt/journal/config/srv-journal-docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 
 services:
-    {% if pillar.journal.get('redis_cache') == false %}
+    {% if not pillar.journal.get('redis_cache') %}
     redis:
         image: redis:3.2.10-alpine
     {% endif %}


### PR DESCRIPTION
Part of https://github.com/elifesciences/issues/issues/3676

Supported cases: `null` (local container), `true` (ElastiCache).