### PR TITLE
Remove elifesciences/journal_web reference

### DIFF
--- a/salt/journal/config/srv-journal-docker-compose.yml
+++ b/salt/journal/config/srv-journal-docker-compose.yml
@@ -28,7 +28,6 @@ services:
             dockerfile: Dockerfile.web
             args:
                 image_tag: ${IMAGE_TAG}
-        image: "elifesciences/journal_web:${IMAGE_TAG}"
         restart: always
         volumes:
             - ./nginx-assets.conf:/etc/nginx/conf.d/default.conf


### PR DESCRIPTION
`image` shouldn't be needed as it's in the Dockerfile.