### PR TITLE
Add redirects for old URLs

### DIFF
--- a/salt/journal/config/etc-nginx-sites-available-journal.conf
+++ b/salt/journal/config/etc-nginx-sites-available-journal.conf
@@ -79,9 +79,8 @@ server {
 
         add_header Cache-Control "public, max-age={{ 60 * 60 * 24 * 7 }}";
 
-        rewrite '^/content(/elife)?/[0-9]{1,}/e([0-9]{5,})(v.)?(/.*)?$' '{{ public_scheme }}://{{ public_host }}/articles/$2$3' permanent;
-        rewrite '^/content(/elife)?/[0-9]{1,}/e([0-9]{5,})(v.)?(-download(.figures)?)?.[a-z0-9]+$' '{{ public_scheme }}://{{ public_host }}/articles/$2$3' permanent;
-        rewrite '^/content(/elife)?/early/[0-9]{4}/[0-9]{2}/[0-9]{2}/eLife.([0-9]{5,})(\..*)?$' '{{ public_scheme }}://{{ public_host }}/articles/$2' permanent;
+        rewrite '^/(?:cgi|content|elife)/.+?/(?:e|eLife\.)?([0-9]{5,})(v[0-9]+)?' '{{ public_scheme }}://{{ public_host }}/articles/$1$2' permanent;
+        rewrite '^/keywords/(.*)$' '{{ public_scheme }}://{{ public_host }}/search?for=$1' permanent;
         rewrite '^/(.*)/$' '{{ public_scheme }}://{{ public_host }}/$1' permanent;
         rewrite '^/About$' '{{ public_scheme }}://{{ public_host }}/about' permanent;
         rewrite '^/Community$' '{{ public_scheme }}://{{ public_host }}/community' permanent;


### PR DESCRIPTION
Based on the 404 list in Google Search Console, eg

- `/elife/citation/371640/bibtex`
- `/keywords/polymeric-ig-receptor-pigr`
- `/cgi/reprint/3/0/e03604`

(And simplifies what's already there.)