### PR TITLE
Fix: adds missing semi-colon to end of robots.txt line

### DIFF
--- a/salt/journal/config/etc-nginx-traits.d-robots.conf
+++ b/salt/journal/config/etc-nginx-traits.d-robots.conf
@@ -2,5 +2,5 @@
 # allow everything only on main hostname
 location /robots.txt {
     add_header Content-Type text/plain;
-    return 200 "User-Agent: *\nDisallow: $robots_disallow\nDisallow: /download/\n\nUser-agent: Amazonbot\nDisallow: /search/\n\nUser-agent: turnitinbot\nDisallow: /search/\n"
+    return 200 "User-Agent: *\nDisallow: $robots_disallow\nDisallow: /download/\n\nUser-agent: Amazonbot\nDisallow: /search/\n\nUser-agent: turnitinbot\nDisallow: /search/\n";
 }


### PR DESCRIPTION
fyi @thewilkybarkid , @giorgiosironi 

not sure how this got past testing. I'd seen the highstate failures for a couple of days but the log files were empty. Today I ran highstate manually to see if that would trigger it and saw this. journal--prod--1 is down but journal--prod--2 is still up, presumably because highstate isn't run on subsequent nodes if it fails on the first 