### PR TITLE
Add redirect for executive director appointment

### DIFF
--- a/salt/journal/config/etc-nginx-traits.d-redirect-existing-paths.conf
+++ b/salt/journal/config/etc-nginx-traits.d-redirect-existing-paths.conf
@@ -1452,4 +1452,6 @@ map $uri $new_uri {
     '/inside-elife/49468030/elife-latest-introducing-the-first-demonstration-of-the-open-source-publishing-platform-libero-publisher' '/for-the-press/d5b3c1bf';
     '/jobs/9231bab7' '/inside-elife/bbc6f6d5';
     '/jobs/9231bab7/executive-director' '/inside-elife/bbc6f6d5';
+    '/inside-elife/a81452c9' '/for-the-press/387b0c3f';
+    '/inside-elife/a81452c9/elife-names-damian-pattinson-as-new-executive-director' '/for-the-press/387b0c3f';
 }


### PR DESCRIPTION
This implements a redirect from the inside elife article to the press pack for the executive director appointment. As press pack is not supported for announcements this is the recognised work around for this issue.