### PR TITLE
salt 2019.2 upgrade

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-elifeFormula('journal', '/srv/journal', null, ['s1804', 'snsalt'])
+elifeFormula('journal', '/srv/journal', null, ['snsalt'])


### PR DESCRIPTION
jenkinsfile, removes s1804 build.
1804 is now default for journal