### PR TITLE
Add path to recent by subject RSS feed

### DIFF
--- a/salt/journal/config/etc-nginx-sites-available-journal.conf
+++ b/salt/journal/config/etc-nginx-sites-available-journal.conf
@@ -153,6 +153,12 @@ server {
         proxy_read_timeout 30s;
     }
 
+    location = /rss/recent-by-subject.xml {
+        proxy_pass {{ pillar.journal.observer_url }}/report/latest-articles-by-subject.rss;
+        proxy_connect_timeout 5s;
+        proxy_read_timeout 30s;
+    }
+
     location = /ping-fastly {
         add_header Cache-Control "must-revalidate, no-cache, no-store, private";
         add_header Content-Type "text/plain; charset=UTF-8";

--- a/salt/journal/config/etc-nginx-sites-available-journal.conf
+++ b/salt/journal/config/etc-nginx-sites-available-journal.conf
@@ -153,8 +153,8 @@ server {
         proxy_read_timeout 30s;
     }
 
-    location = /rss/recent-by-subject.xml {
-        proxy_pass {{ pillar.journal.observer_url }}/report/latest-articles-by-subject.rss;
+    location ~* ^/rss/recent-([a-z0-9-]+).xml {
+        proxy_pass {{ pillar.journal.observer_url }}/report/latest-articles-by-subject.rss?subject=$1;
         proxy_connect_timeout 5s;
         proxy_read_timeout 30s;
     }

--- a/salt/journal/config/etc-nginx-sites-available-journal.conf
+++ b/salt/journal/config/etc-nginx-sites-available-journal.conf
@@ -153,7 +153,7 @@ server {
         proxy_read_timeout 30s;
     }
 
-    location ~* ^/rss/recent-([a-z0-9-]+).xml {
+    location ~* ^/rss/subject/([a-z0-9-]+).xml {
         proxy_pass {{ pillar.journal.observer_url }}/report/latest-articles-by-subject.rss?subject=$1;
         proxy_connect_timeout 5s;
         proxy_read_timeout 30s;

--- a/salt/journal/config/etc-nginx-sites-available-journal.conf
+++ b/salt/journal/config/etc-nginx-sites-available-journal.conf
@@ -153,7 +153,7 @@ server {
         proxy_read_timeout 30s;
     }
 
-    location ~* ^/rss/subject/([a-z0-9-]+).xml {
+    location ~* ^/rss/subject/([a-z0-9-]+).xml$ {
         proxy_pass {{ pillar.journal.observer_url }}/report/latest-articles-by-subject.rss?subject=$1;
         proxy_connect_timeout 5s;
         proxy_read_timeout 30s;


### PR DESCRIPTION
The path `/rss/subject/biochemistry.xml` should become a proxy for `https://prod--observer.elifesciences.org/report/latest-articles-by-subject.rss?subject=biochemistry`