### PR TITLE
Remove nginx access log from loggly transfer

### DIFF
--- a/salt/journal/config/etc-syslog-ng-conf.d-journal.conf
+++ b/salt/journal/config/etc-syslog-ng-conf.d-journal.conf
@@ -8,14 +8,6 @@ source s_journal_application {
     ); 
 };
 
-source s_journal_nginx_access {
-    file("/var/log/nginx/journal.access.log" 
-         follow_freq(1)
-         program_override("nginx")
-         flags(no-parse) 
-    ); 
-};
-
 source s_journal_nginx_error {
     file("/var/log/nginx/journal.error.log" 
          follow_freq(1)
@@ -27,7 +19,6 @@ source s_journal_nginx_error {
 {% if pillar.elife.logging.loggly.enabled %}
 log {
     source(s_journal_application);
-    source(s_journal_nginx_access);
     source(s_journal_nginx_error);
     destination(d_loggly);
 };


### PR DESCRIPTION
Since the `journal.error.log` file contains all messages that are equal or more severe than `notice` I believe we can afford to not transfer the `journal.access.log` to loggly.

https://github.com/elifesciences/journal-formula/blob/40ae9465cf1f57ec19d8f322262f1e8c1c62f8ec/salt/journal/config/etc-nginx-sites-available-journal.conf#L193