### PR TITLE
tweak to EPP redirect rules.

### DIFF
--- a/salt/journal/config/etc-nginx-sites-available-journal.conf
+++ b/salt/journal/config/etc-nginx-sites-available-journal.conf
@@ -196,21 +196,15 @@ server {
 
     {% if pillar.journal.preprint_url %}
 
-    # lsh@2022-10: nginx does special handling when the URI (the trailing slash) is not supplied in proxy_pass.
-    # when "/reviewed-preprints" (a landing page) is requested, the URI (/) won't exist, causing nginx to, 
-    # (I think !), call "https://example.org/reviewed-prints" rather than "https://example.org/"
-    # - https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_pass
+    # lsh@2022-10: journal handles the landing page ("/reviewed-preprints") and it's 
+    # trailing slash alias ("/reviewed-preprints/"), anything else is proxied to EPP.
 
-    # "/reviewed-preprints" => "https://example.org/"
-    location /reviewed-preprints {
-        proxy_pass {{ pillar.journal.preprint_url }}/;
-        proxy_connect_timeout 5s;
-        proxy_read_timeout 5s;
-    }
-
-    # "/reviewed-preprints/" => "https://example.org/"
-    location /reviewed-preprints/ {
-        proxy_pass {{ pillar.journal.preprint_url }}/;
+    # "/reviewed-preprints/"    => "https://example.org/reviewed-preprints"     (301)
+    # "/reviewed-preprints"     => "https://example.org/reviewed-preprints"     (200)
+    # "/reviewed-preprints/foo" => "https://proxy.tld/reviewed-preprints/foo"   (200)
+    location ~ ^/reviewed-preprints/(.+)$ {
+        proxy_pass {{ pillar.journal.preprint_url }};
+        # arbitrary, adjust as we get a feel for EPP's performance.
         proxy_connect_timeout 5s;
         proxy_read_timeout 5s;
     }

--- a/salt/pillar/journal.sls
+++ b/salt/pillar/journal.sls
@@ -4,6 +4,7 @@ journal:
     api_key: public
     side_by_side_view_url: https://lens.elifesciences.org/
     observer_url: https://observer.elifesciences.org/
+    # no trailing slashes. leave empty to prevent adding redirect rules
     preprint_url: https://staging--epp.elifesciences.org
     default_host: null
 


### PR DESCRIPTION
the journal should handle the landing page and it's trailing slash alias, everything else goes to EPP.