### PR TITLE
Proxy about pages

### DIFF
--- a/salt/journal/config/etc-nginx-sites-available-journal.conf
+++ b/salt/journal/config/etc-nginx-sites-available-journal.conf
@@ -214,15 +214,15 @@ server {
     {% if pillar.journal.about_url %}
 
     # scottaubrey@2023-101: Proxy most about/* pages to pubpub, except /about/people*
-    # "/about"                  => proxy (as /about/home)
-    # "/about/"                 => proxy (as /about/home)
-    # "/about/home"             => proxy
-    # "/about/cheese"           => proxy
+    # "/about"                  => proxy (as /about)
+    # "/about/"                 => proxy (as /about)
+    # "/about/about"            => proxy (as /about)
+    # "/about/cheese"           => proxy (as /cheese)
     # "/about/people"           => no proxy
     # "/about/people/medicine"  => no proxy
     location ~ ^/about(?!/people).*$ {
-        # rewrite /about and /about/ to /home before passing to proxy
-        rewrite '^/about[/]{0,1}$' /home break;
+        # rewrite /about and /about/ to /about before passing to proxy
+        rewrite '^/about[/]{0,1}$' /about break;
         # rewrite /about/* to /* before passing to proxy
         rewrite '^/about/(.*)$' /$1 break;
 

--- a/salt/journal/config/etc-nginx-sites-available-journal.conf
+++ b/salt/journal/config/etc-nginx-sites-available-journal.conf
@@ -214,12 +214,16 @@ server {
     {% if pillar.journal.about_url %}
 
     # scottaubrey@2023-101: Proxy most about/* pages to pubpub, except /about/people*
-    # "/about"                  => proxy
-    # "/about/"                 => proxy
+    # "/about"                  => proxy (as /about/home)
+    # "/about/"                 => proxy (as /about/home)
+    # "/about/home"             => proxy
     # "/about/cheese"           => proxy
     # "/about/people"           => no proxy
     # "/about/people/medicine"  => no proxy
     location ~ ^/about(?!/people).*$ {
+        # redirect /about and /about/ to /about/home before passing to proxy
+        rewrite '^/about[/]{0,1}$' /about/home break;
+
         proxy_pass {{ pillar.journal.about_url }};
         # arbitrary, but it is outside of our AWS network.
         proxy_connect_timeout 10s;

--- a/salt/journal/config/etc-nginx-sites-available-journal.conf
+++ b/salt/journal/config/etc-nginx-sites-available-journal.conf
@@ -221,8 +221,10 @@ server {
     # "/about/people"           => no proxy
     # "/about/people/medicine"  => no proxy
     location ~ ^/about(?!/people).*$ {
-        # redirect /about and /about/ to /about/home before passing to proxy
-        rewrite '^/about[/]{0,1}$' /about/home break;
+        # rewrite /about and /about/ to /home before passing to proxy
+        rewrite '^/about[/]{0,1}$' /home break;
+        # rewrite /about/* to /* before passing to proxy
+        rewrite '^/about/(.*)$' /$1 break;
 
         proxy_pass {{ pillar.journal.about_url }};
         # arbitrary, but it is outside of our AWS network.

--- a/salt/journal/config/etc-nginx-sites-available-journal.conf
+++ b/salt/journal/config/etc-nginx-sites-available-journal.conf
@@ -196,7 +196,7 @@ server {
 
     {% if pillar.journal.preprint_url %}
 
-    # lsh@2022-10: journal handles the landing page ("/reviewed-preprints") and it's 
+    # lsh@2022-10: journal handles the landing page ("/reviewed-preprints") and it's
     # trailing slash alias ("/reviewed-preprints/"), anything else is proxied to EPP.
 
     # "/reviewed-preprints/"    => "https://example.org/reviewed-preprints"     (301)
@@ -211,8 +211,25 @@ server {
 
     {% endif %}
 
+    {% if pillar.journal.about_url %}
+
+    # scottaubrey@2023-101: Proxy most about/* pages to pubpub, except /about/people*
+    # "/about"                  => proxy
+    # "/about/"                 => proxy
+    # "/about/cheese"           => proxy
+    # "/about/people"           => no proxy
+    # "/about/people/medicine"  => no proxy
+    location ~ ^/about(?!/people).*$ {
+        proxy_pass {{ pillar.journal.about_url }};
+        # arbitrary, but it is outside of our AWS network.
+        proxy_connect_timeout 10s;
+        proxy_read_timeout 10s;
+    }
+
+    {% endif %}
+
     access_log /var/log/nginx/journal.access.log combined_with_time;
     error_log /var/log/nginx/journal.error.log notice;
-    
+
     include /etc/nginx/traits.d/error-pages.conf;
 }

--- a/salt/pillar/journal.sls
+++ b/salt/pillar/journal.sls
@@ -6,6 +6,8 @@ journal:
     observer_url: https://observer.elifesciences.org/
     # no trailing slashes. leave empty to prevent adding redirect rules
     preprint_url: https://staging--epp.elifesciences.org
+    # no trailing slashes. leave empty to prevent adding redirect rules
+    about_url:
     default_host: null
 
     submit_url: https://submit.elifesciences.org/


### PR DESCRIPTION
Relates to https://github.com/elifesciences/enhanced-preprints-issues/issues/416

Depends on  https://github.com/elifesciences/builder-configuration/pull/304

If specified, implement an about page proxy that:
1) accepts anything but /about/people (which should be handle by journal)
2) transparently rewrites /about and /about/ to /about for the receiving proxy
2) transparently rewrites /about/* to /* for the receiving proxy