### PR TITLE
add `/dist` as a proxy through to pubpub too. 

### DIFF
--- a/salt/journal/config/etc-nginx-sites-available-journal.conf
+++ b/salt/journal/config/etc-nginx-sites-available-journal.conf
@@ -213,7 +213,7 @@ server {
 
     {% if pillar.journal.about_url %}
 
-    # scottaubrey@2023-101: Proxy most about/* pages to pubpub, except /about/people*
+    # scottaubrey@2023-01: Proxy most about/* pages to pubpub, except /about/people*
     # "/about"                  => proxy (as /about)
     # "/about/"                 => proxy (as /about)
     # "/about/about"            => proxy (as /about)
@@ -230,6 +230,14 @@ server {
         # https://serverfault.com/questions/583374/configure-nginx-as-reverse-proxy-with-upstream-ssl#answer-969851
         proxy_ssl_server_name on;
         # arbitrary, but it is outside of our AWS network.
+        proxy_connect_timeout 10s;
+        proxy_read_timeout 10s;
+    }
+    # scottaubrey@2023-01: Proxy dist/* pages to pubpub to get the static assets
+    # This is to work around pubpub not being able to configure reference static assets URL
+    location ~ ^/dist/(.*)$ {
+        proxy_pass {{ pillar.journal.about_url }};
+        proxy_ssl_server_name on;
         proxy_connect_timeout 10s;
         proxy_read_timeout 10s;
     }

--- a/salt/journal/config/etc-nginx-sites-available-journal.conf
+++ b/salt/journal/config/etc-nginx-sites-available-journal.conf
@@ -233,7 +233,7 @@ server {
         proxy_connect_timeout 10s;
         proxy_read_timeout 10s;
     }
-    # scottaubrey@2023-01: Proxy dist/* pages to pubpub to get the static assets
+    # scottaubrey@2023-01: Proxy dist/* URLs to pubpub to get the static assets
     # This is to work around pubpub not being able to configure reference static assets URL
     location ~ ^/dist/(.*)$ {
         proxy_pass {{ pillar.journal.about_url }};


### PR DESCRIPTION
This is to resolve the base URL issue with pubpub before launch.

relates to: https://github.com/elifesciences/enhanced-preprints-issues/issues/416