### PR TITLE
add a new key to facilitate /submit redirect

### DIFF
--- a/salt/journal/config/etc-nginx-sites-available-journal.conf
+++ b/salt/journal/config/etc-nginx-sites-available-journal.conf
@@ -236,6 +236,10 @@ server {
 
     {% endif %}
 
+    {% if pillar.journal.submit_redirect_url %}
+    rewrite '^/submit[/]*$' {{ pillar.journal.submit_redirect_url }} permanent;
+    {% endif %}
+
     access_log /var/log/nginx/journal.access.log combined_with_time;
     error_log /var/log/nginx/journal.error.log notice;
 

--- a/salt/pillar/journal.sls
+++ b/salt/pillar/journal.sls
@@ -10,7 +10,9 @@ journal:
     about_url:
     default_host: null
 
-    submit_url: https://submit.elifesciences.org/
+    # This parameter, if truthy, redirects /submit to the given value.
+    # This is different from submit_url and submit_url_redirects, in that these values exist for journal code
+    submit_redirect_url:
 
     crm_api_key: ~
     crm_api_site_key: ~

--- a/salt/pillar/journal.sls
+++ b/salt/pillar/journal.sls
@@ -14,7 +14,7 @@ journal:
 
     # This parameter, if truthy, redirects /submit to the given value.
     # This is different from submit_url and submit_url_redirects, in that these values exist for journal code
-    submit_redirect_url:
+    submit_redirect_url: ~
 
     crm_api_key: ~
     crm_api_site_key: ~

--- a/salt/pillar/journal.sls
+++ b/salt/pillar/journal.sls
@@ -14,7 +14,7 @@ journal:
 
     # This parameter, if truthy, redirects /submit to the given value.
     # This is different from submit_url and submit_url_redirects, in that these values exist for journal code
-    submit_redirect_url: ~
+    submit_redirect_url:
 
     crm_api_key: ~
     crm_api_site_key: ~

--- a/salt/pillar/journal.sls
+++ b/salt/pillar/journal.sls
@@ -10,6 +10,8 @@ journal:
     about_url:
     default_host: null
 
+    submit_url: https://submit.elifesciences.org/
+
     # This parameter, if truthy, redirects /submit to the given value.
     # This is different from submit_url and submit_url_redirects, in that these values exist for journal code
     submit_redirect_url:


### PR DESCRIPTION
This redirects the request before it reaches the journal app, avoiding the overhead of all the (soon to be obsolete) config there.

The key is awkward, because we're using a couple of similar sounding keys for journal config (that is only used in some environments anyway). We will be dropping that code soon, then we can rename keys in here and builder-configuration (if necessary) then.

Related PR: https://github.com/elifesciences/builder-configuration/pull/306

relates to: https://github.com/elifesciences/enhanced-preprints-issues/issues/414