### PR TITLE
fix issue with redirecting to the host rather than the public url

### DIFF
--- a/salt/journal/config/etc-nginx-sites-available-journal.conf
+++ b/salt/journal/config/etc-nginx-sites-available-journal.conf
@@ -222,7 +222,7 @@ server {
     # "/about/people/medicine"  => no proxy
     location ~ ^/about(?!/people).*$ {
         # rewrite /about to /about/
-        rewrite '^/about$' '/about/' permanent;
+        rewrite '^/about$' '{{ public_scheme }}://{{ public_host }}/about/' permanent;
         # rewrite /about/ to /about before passing to proxy
         rewrite '^/about[/]{0,1}$' /about break;
         # rewrite /about/* to /* before passing to proxy


### PR DESCRIPTION
Redirect is currently happening to the prod--journal hostname:
```
curl -sI https://elifesciences.org/about | grep location
location: http://prod--journal.elifesciences.org/about/
```

This PR fixes it to use public URL instead.