### PR TITLE
feat: add new redirects in nginx configuration

### DIFF
--- a/salt/journal/config/etc-nginx-traits.d-redirect-existing-paths.conf
+++ b/salt/journal/config/etc-nginx-traits.d-redirect-existing-paths.conf
@@ -1462,4 +1462,8 @@ map $uri $new_uri {
     '/inside-elife/a81452c9/elife-latest-we-name-damian-pattinson-as-new-executive-director' '/for-the-press/387b0c3f';
     '/inside-elife/3af2321c' '/events/7a007be0';
     '/inside-elife/3af2321c/elife-s-new-publishing-model-ask-our-editorial-team-your-questions' '/events/7a007be0';
+    '/jobs/430893bd' '/about/eic-job-description';
+    '/jobs/430893bd/editor-in-chief' '/about/eic-job-description';
+    '/jobs/35265f38' '/about/board-member-job-description';
+    '/jobs/35265f38/board-of-directors' '/about/board-member-job-description';
 }


### PR DESCRIPTION
New redirects have been added in the nginx configuration file for '/jobs/430893bd', '/jobs/430893bd/editor-in-chief', '/jobs/35265f38', and '/jobs/35265f38/board-of-directors' paths.