### PR TITLE
add redirect privacy-policy and cookie-declaration to pubpub 

### DIFF
--- a/salt/journal/config/etc-nginx-sites-available-journal.conf
+++ b/salt/journal/config/etc-nginx-sites-available-journal.conf
@@ -336,7 +336,7 @@ server {
     }
     {% endif -%}
 
-    {% if pillar.journal.cookie_declaration %}
+    {% if pillar.journal.cookie_declaration_url %}
     # Proxy /cookie-declaration pages to pubpub
     location ~ ^/cookie-declaration[/]* {
         proxy_pass {{ pillar.journal.cookie_declaration_url }};

--- a/salt/journal/config/etc-nginx-sites-available-journal.conf
+++ b/salt/journal/config/etc-nginx-sites-available-journal.conf
@@ -325,7 +325,7 @@ server {
     }
     {% endif -%}
 
-    {% if pillar.journal.privacy-policy %}
+    {% if pillar.journal.privacy_policy_url %}
     # Proxy /privacy-policy pages to pubpub
     location ~ ^/privacy-policy[/]* {
         proxy_pass {{ pillar.journal.privacy_notice_url }};
@@ -336,9 +336,8 @@ server {
     }
     {% endif -%}
 
-     {% if pillar.journal.cookie-declaration %}
+    {% if pillar.journal.cookie_declaration %}
     # Proxy /cookie-declaration pages to pubpub
-
     location ~ ^/cookie-declaration[/]* {
         proxy_pass {{ pillar.journal.cookie_declaration_url }};
         proxy_ssl_server_name on;
@@ -348,7 +347,7 @@ server {
     }
     {% endif -%}
 
-    {% if pillar.journal.about_url or pillar.journal.resources_url or pillar.journal.media_policy_url or pillar.journal.community_url or pillar.journal.privacy_potice_url or pillar.journal.cookie_declaration_url %}
+    {% if pillar.journal.about_url or pillar.journal.resources_url or pillar.journal.media_policy_url or pillar.journal.community_url or pillar.journal.privacy_notice_url or pillar.journal.cookie_declaration_url %}
 
     # lsh@2023-11: revisit these pubpub proxies if/when we get a third path to proxy.
     # scottaubrey@2023-01: Proxy dist/* URLs to pubpub to get the static assets

--- a/salt/journal/config/etc-nginx-sites-available-journal.conf
+++ b/salt/journal/config/etc-nginx-sites-available-journal.conf
@@ -325,8 +325,30 @@ server {
     }
     {% endif -%}
 
+    {% if pillar.journal.privacy-policy %}
+    # Proxy /privacy-policy pages to pubpub
+    location ~ ^/privacy-policy[/]* {
+        proxy_pass {{ pillar.journal.privacy_notice_url }};
+        proxy_ssl_server_name on;
+        proxy_connect_timeout 10s;
+        proxy_read_timeout 10s;
+        proxy_set_header X-PubPubClient elifesciences;
+    }
+    {% endif -%}
 
-    {% if pillar.journal.about_url or pillar.journal.resources_url or pillar.journal.media_policy_url or pillar.journal.community_url %}
+     {% if pillar.journal.cookie-declaration %}
+    # Proxy /cookie-declaration pages to pubpub
+
+    location ~ ^/cookie-declaration[/]* {
+        proxy_pass {{ pillar.journal.cookie_declaration_url }};
+        proxy_ssl_server_name on;
+        proxy_connect_timeout 10s;
+        proxy_read_timeout 10s;
+        proxy_set_header X-PubPubClient elifesciences;
+    }
+    {% endif -%}
+
+    {% if pillar.journal.about_url or pillar.journal.resources_url or pillar.journal.media_policy_url or pillar.journal.community_url or pillar.journal.privacy_potice_url or pillar.journal.cookie_declaration_url %}
 
     # lsh@2023-11: revisit these pubpub proxies if/when we get a third path to proxy.
     # scottaubrey@2023-01: Proxy dist/* URLs to pubpub to get the static assets

--- a/salt/journal/config/etc-nginx-sites-available-journal.conf
+++ b/salt/journal/config/etc-nginx-sites-available-journal.conf
@@ -305,7 +305,7 @@ server {
     # "/community/ambassadors"                     => proxy (as /ambassadors)
     # "/community/community-alumni"                => proxy (as /community-alumni)
     # "/community/community-voices"                => proxy (as /community-voices)
-    
+
 
     location ^~ /community {
         # rewrite /community to /community/
@@ -325,7 +325,7 @@ server {
     }
     {% endif -%}
 
-    {% if pillar.journal.privacy_policy_url %}
+    {% if pillar.journal.privacy_notice_url %}
     # Proxy /privacy-policy pages to pubpub
     location ~ ^/privacy-policy[/]* {
         proxy_pass {{ pillar.journal.privacy_notice_url }};

--- a/salt/journal/config/etc-nginx-sites-available-journal.conf
+++ b/salt/journal/config/etc-nginx-sites-available-journal.conf
@@ -327,7 +327,7 @@ server {
 
     {% if pillar.journal.privacy_notice_url %}
     # Proxy /privacy-policy pages to pubpub
-    location ~ ^/privacy-policy[/]* {
+    location /privacy-policy {
         proxy_pass {{ pillar.journal.privacy_notice_url }};
         proxy_ssl_server_name on;
         proxy_connect_timeout 10s;
@@ -338,7 +338,7 @@ server {
 
     {% if pillar.journal.cookie_declaration_url %}
     # Proxy /cookie-declaration pages to pubpub
-    location ~ ^/cookie-declaration[/]* {
+    location /cookie-declaration {
         proxy_pass {{ pillar.journal.cookie_declaration_url }};
         proxy_ssl_server_name on;
         proxy_connect_timeout 10s;

--- a/salt/pillar/journal.sls
+++ b/salt/pillar/journal.sls
@@ -12,6 +12,8 @@ journal:
     resources_url:
     media_policy_url:
     community_url:
+    privacy_notice_url:
+    cookie_declaration_url:
     default_host: null
 
     submit_url: https://submit.elifesciences.org/


### PR DESCRIPTION
The continuumtest proxy is set on builder-configurations https://github.com/elifesciences/builder-configuration/commit/ad83e8d22b655e068707159cb54c7ae65494e321