### PR TITLE
Remove no longer required redirect to free up the endpoint

### DIFF
--- a/salt/journal/config/etc-nginx-traits.d-redirect-existing-paths.conf
+++ b/salt/journal/config/etc-nginx-traits.d-redirect-existing-paths.conf
@@ -2,7 +2,6 @@ map_hash_bucket_size 518;
 
 map $uri $new_uri {
     '/articles' '/';
-    '/browse' '/';
     '/the-journal' '/';
     '/the-journal/articles' '/';
     '/the-journal/in-press' '/';


### PR DESCRIPTION
Require for the browse by terms work

https://github.com/elifesciences/issues/issues/9146